### PR TITLE
fix: empty similarity search footnotes

### DIFF
--- a/src/handlers/issue-deduplication.ts
+++ b/src/handlers/issue-deduplication.ts
@@ -112,6 +112,10 @@ async function handleSimilarIssuesComment(context: Context, payload: IssuePayloa
       return `[^0${index + 1}^]: [${issue.node.title}](${modifiedUrl}) ${issue.similarity}%`;
     })
     .join("\n");
+
+  if (commentBody.length === 0) {
+    return;
+  }
   const footnoteLinks = [...Array(++finalIndex).keys()].map((i) => `[^0${i + 1}^]`).join("");
   const body = "\n###### Similar " + footnoteLinks + "\n\n" + commentBody;
 


### PR DESCRIPTION
Resolves #28 

- Filtering by Org/Repo resulted in an empty footnotes section, but that has been fixed.